### PR TITLE
Add wallet management and gacha endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ make format
 ### Endpoints
 
 - `GET /health` - Vérification de santé du service
+- `GET /wallets/<user_id>` - Récupération du portefeuille et de l'historique
+- `POST /wallets/<user_id>/topup` - Créditer un portefeuille
+- `POST /wallets/<user_id>/spend` - Débiter un portefeuille avec validation de solde
+- `GET /wallets/<user_id>/transactions` - Historique détaillé des transactions
+- `GET /gacha/pools` - Liste des pools disponibles avec leurs récompenses
+- `POST /gacha/draw` - Tirage gacha avec consommation automatique des fonds
 
 ### Format des Réponses
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,36 +1,377 @@
-"""
-umbra-payment-service - Service de paiement, monétisation et système gacha
-"""
+"""umbra-payment-service - Service de paiement, monétisation et système gacha."""
+
+from __future__ import annotations
+
 import os
-from flask import Flask, jsonify
+import random
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Dict, List, Optional
+
+from flask import Flask, jsonify, request
 from flask_cors import CORS
+
+
+# ----------------------------------------------------------------------------
+# Modèles métiers
+# ----------------------------------------------------------------------------
+
+
+def _to_decimal(value: Any) -> Decimal:
+    """Convertit une valeur en :class:`~decimal.Decimal` avec deux décimales."""
+
+    if isinstance(value, Decimal):  # Accept déjà décimal
+        decimal_value = value
+    else:
+        try:
+            decimal_value = Decimal(str(value))
+        except (InvalidOperation, ValueError, TypeError) as exc:  # pragma: no cover - defensive
+            raise ValueError("Montant invalide") from exc
+
+    quantized = decimal_value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    if quantized < Decimal("0.00"):
+        raise ValueError("Le montant doit être positif")
+    return quantized
+
+
+@dataclass
+class Wallet:
+    """Représente le portefeuille d'un utilisateur."""
+
+    user_id: str
+    balance: Decimal = Decimal("0.00")
+    currency: str = "UMBC"  # Umbra Coins
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "balance": float(self.balance),
+            "currency": self.currency,
+        }
+
+
+@dataclass
+class Transaction:
+    """Historique d'une opération sur un portefeuille."""
+
+    id: str
+    user_id: str
+    type: str
+    amount: Decimal
+    balance_after: Decimal
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "type": self.type,
+            "amount": float(self.amount),
+            "balance_after": float(self.balance_after),
+            "metadata": self.metadata,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class PaymentError(Exception):
+    """Erreur générique du service de paiement."""
+
+
+class InsufficientFundsError(PaymentError):
+    """Levée lorsqu'un portefeuille n'a pas assez de fonds."""
+
+
+class PaymentStore:
+    """Stockage mémoire pour les portefeuilles et transactions."""
+
+    def __init__(self) -> None:
+        self._wallets: Dict[str, Wallet] = {}
+        self._transactions: Dict[str, List[Transaction]] = {}
+
+    # -- Gestion des portefeuilles -------------------------------------------------
+    def get_wallet(self, user_id: str) -> Wallet:
+        if user_id not in self._wallets:
+            self._wallets[user_id] = Wallet(user_id=user_id)
+        return self._wallets[user_id]
+
+    def _record_transaction(self, transaction: Transaction) -> None:
+        self._transactions.setdefault(transaction.user_id, []).append(transaction)
+
+    def top_up(
+        self,
+        user_id: str,
+        amount: Decimal,
+        source: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Transaction:
+        wallet = self.get_wallet(user_id)
+        wallet.balance += amount
+
+        transaction = Transaction(
+            id=str(uuid.uuid4()),
+            user_id=user_id,
+            type="topup",
+            amount=amount,
+            balance_after=wallet.balance,
+            metadata={"source": source, **(metadata or {})} if source or metadata else metadata or {},
+        )
+        self._record_transaction(transaction)
+        return transaction
+
+    def spend(
+        self,
+        user_id: str,
+        amount: Decimal,
+        reason: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Transaction:
+        wallet = self.get_wallet(user_id)
+        if wallet.balance < amount:
+            raise InsufficientFundsError("Fonds insuffisants pour cette opération")
+
+        wallet.balance -= amount
+
+        transaction = Transaction(
+            id=str(uuid.uuid4()),
+            user_id=user_id,
+            type="spend",
+            amount=amount,
+            balance_after=wallet.balance,
+            metadata={"reason": reason, **(metadata or {})} if reason or metadata else metadata or {},
+        )
+        self._record_transaction(transaction)
+        return transaction
+
+    def list_transactions(self, user_id: str) -> List[Transaction]:
+        return list(self._transactions.get(user_id, []))
+
+
+# ----------------------------------------------------------------------------
+# Configuration des pools Gacha
+# ----------------------------------------------------------------------------
+
+
+def _default_gacha_pools() -> Dict[str, Dict[str, Any]]:
+    return {
+        "standard": {
+            "cost": Decimal("10.00"),
+            "items": [
+                {"name": "Bague de Cuivre", "rarity": "common", "weight": 70},
+                {"name": "Amulette d'Argent", "rarity": "rare", "weight": 25},
+                {"name": "Lame d'Ombre", "rarity": "legendary", "weight": 5},
+            ],
+        },
+        "premium": {
+            "cost": Decimal("30.00"),
+            "items": [
+                {"name": "Cristal Azur", "rarity": "rare", "weight": 60},
+                {"name": "Relique Ancienne", "rarity": "epic", "weight": 30},
+                {"name": "Couronne du Néant", "rarity": "mythic", "weight": 10},
+            ],
+        },
+    }
+
+
+def _serialise_pool(name: str, pool: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "cost": float(pool["cost"]),
+        "items": [
+            {"name": item["name"], "rarity": item["rarity"], "weight": item["weight"]}
+            for item in pool["items"]
+        ],
+    }
+
+
+# ----------------------------------------------------------------------------
+# Application Flask
+# ----------------------------------------------------------------------------
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
     CORS(app)
-    
+
     # Configuration
-    app.config['DEBUG'] = os.getenv('FLASK_DEBUG', '0') == '1'
-    
+    app.config["DEBUG"] = os.getenv("FLASK_DEBUG", "0") == "1"
+    app.config.setdefault("GACHA_POOLS", _default_gacha_pools())
+    app.config.setdefault("PAYMENT_STORE", PaymentStore())
+
+    seed = os.getenv("GACHA_RANDOM_SEED")
+    rng = random.Random(int(seed)) if seed is not None else random.Random()
+    app.config.setdefault("GACHA_RANDOM", rng)
+
     # Health check endpoint
-    @app.route('/health')
+    @app.route("/health")
     def health():
-        return jsonify({
-            'success': True,
-            'data': {
-                'status': 'healthy',
-                'service': 'umbra-payment-service'
+        return _json_success(
+            message="Service en bonne santé",
+            data={"status": "healthy", "service": "umbra-payment-service"},
+        )
+
+    # ------------------------------------------------------------------
+    # Portefeuilles
+    # ------------------------------------------------------------------
+    @app.route("/wallets/<string:user_id>", methods=["GET"])
+    def get_wallet_endpoint(user_id: str):
+        store: PaymentStore = app.config["PAYMENT_STORE"]
+        wallet = store.get_wallet(user_id)
+        transactions = [tx.as_dict() for tx in store.list_transactions(user_id)]
+        return _json_success(
+            message="Portefeuille récupéré",
+            data={"wallet": wallet.as_dict(), "transactions": transactions},
+        )
+
+    @app.route("/wallets/<string:user_id>/topup", methods=["POST"])
+    def wallet_top_up(user_id: str):
+        payload = request.get_json(silent=True) or {}
+        amount = payload.get("amount")
+        source = payload.get("source")
+        metadata = payload.get("metadata")
+
+        try:
+            decimal_amount = _to_decimal(amount)
+        except ValueError as exc:
+            return _json_error("Montant invalide", str(exc), status=400)
+
+        store: PaymentStore = app.config["PAYMENT_STORE"]
+        transaction = store.top_up(user_id, decimal_amount, source=source, metadata=metadata)
+        wallet = store.get_wallet(user_id)
+        return _json_success(
+            message="Portefeuille crédité",
+            data={
+                "wallet": wallet.as_dict(),
+                "transaction": transaction.as_dict(),
             },
-            'message': 'Service en bonne santé'
-        }), 200
-    
-    # TODO: Ajouter les routes spécifiques au service
-    
+        )
+
+    @app.route("/wallets/<string:user_id>/spend", methods=["POST"])
+    def wallet_spend(user_id: str):
+        payload = request.get_json(silent=True) or {}
+        amount = payload.get("amount")
+        reason = payload.get("reason")
+        metadata = payload.get("metadata")
+
+        try:
+            decimal_amount = _to_decimal(amount)
+        except ValueError as exc:
+            return _json_error("Montant invalide", str(exc), status=400)
+
+        store: PaymentStore = app.config["PAYMENT_STORE"]
+        try:
+            transaction = store.spend(user_id, decimal_amount, reason=reason, metadata=metadata)
+        except InsufficientFundsError as exc:
+            return _json_error("Fonds insuffisants", str(exc), status=400)
+
+        wallet = store.get_wallet(user_id)
+        return _json_success(
+            message="Paiement effectué",
+            data={
+                "wallet": wallet.as_dict(),
+                "transaction": transaction.as_dict(),
+            },
+        )
+
+    @app.route("/wallets/<string:user_id>/transactions", methods=["GET"])
+    def wallet_transactions(user_id: str):
+        store: PaymentStore = app.config["PAYMENT_STORE"]
+        transactions = [tx.as_dict() for tx in store.list_transactions(user_id)]
+        return _json_success(
+            message="Transactions récupérées",
+            data={"transactions": transactions},
+        )
+
+    # ------------------------------------------------------------------
+    # Gacha
+    # ------------------------------------------------------------------
+    @app.route("/gacha/pools", methods=["GET"])
+    def list_pools():
+        pools = app.config["GACHA_POOLS"]
+        serialised = [_serialise_pool(name, pool) for name, pool in pools.items()]
+        return _json_success(message="Pools disponibles", data={"pools": serialised})
+
+    @app.route("/gacha/draw", methods=["POST"])
+    def draw_items():
+        payload = request.get_json(silent=True) or {}
+        user_id = payload.get("user_id")
+        pool_name = payload.get("pool", "standard")
+        draws = payload.get("draws", 1)
+        seed = payload.get("seed")
+
+        if not user_id:
+            return _json_error("Paramètre manquant", "user_id est requis", status=400)
+
+        try:
+            draws_count = int(draws)
+        except (TypeError, ValueError):
+            return _json_error("Paramètre invalide", "draws doit être un entier", status=400)
+
+        if draws_count <= 0 or draws_count > 50:
+            return _json_error("Paramètre invalide", "draws doit être compris entre 1 et 50", status=400)
+
+        pools: Dict[str, Dict[str, Any]] = app.config["GACHA_POOLS"]
+        if pool_name not in pools:
+            return _json_error("Pool inconnu", f"Le pool '{pool_name}' n'existe pas", status=404)
+
+        pool = pools[pool_name]
+        cost = pool["cost"] * draws_count
+
+        store: PaymentStore = app.config["PAYMENT_STORE"]
+        try:
+            store.spend(user_id, cost, reason=f"gacha:{pool_name}")
+        except InsufficientFundsError as exc:
+            return _json_error("Fonds insuffisants", str(exc), status=400)
+
+        rng = random.Random(int(seed)) if seed is not None else app.config["GACHA_RANDOM"]
+        results = _perform_draws(pool, draws_count, rng)
+
+        wallet = store.get_wallet(user_id)
+        return _json_success(
+            message="Tirage effectué",
+            data={
+                "pool": pool_name,
+                "draws": draws_count,
+                "items": results,
+                "remaining_balance": float(wallet.balance),
+            },
+        )
+
     return app
 
 
-if __name__ == '__main__':
-    app = create_app()
-    port = int(os.getenv('PORT', '5003'))
-    app.run(host='0.0.0.0', port=port, debug=True)
+def _perform_draws(pool: Dict[str, Any], draws: int, rng: random.Random) -> List[Dict[str, Any]]:
+    items = pool["items"]
+    weights = [item["weight"] for item in items]
+    choices = rng.choices(items, weights=weights, k=draws)
+    return [{"name": choice["name"], "rarity": choice["rarity"]} for choice in choices]
+
+
+def _json_success(message: str, data: Optional[Dict[str, Any]] = None, status: int = 200):
+    response = {
+        "success": True,
+        "data": data or {},
+        "message": message,
+        "error": None,
+        "meta": None,
+    }
+    return jsonify(response), status
+
+
+def _json_error(title: str, detail: str, status: int = 400):
+    response = {
+        "success": False,
+        "data": None,
+        "message": title,
+        "error": {"detail": detail},
+        "meta": None,
+    }
+    return jsonify(response), status
+
+
+if __name__ == "__main__":
+    application = create_app()
+    port = int(os.getenv("PORT", "5003"))
+    application.run(host="0.0.0.0", port=port, debug=True)

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -1,0 +1,43 @@
+"""Tests pour les fonctionnalités de gacha."""
+
+
+def _seed_wallet(client, user_id: str, amount: float = 120.0) -> None:
+    response = client.post(f"/wallets/{user_id}/topup", json={"amount": amount})
+    assert response.status_code == 200
+
+
+def test_list_pools(client):
+    response = client.get("/gacha/pools")
+    assert response.status_code == 200
+    payload = response.get_json()
+    pools = payload["data"]["pools"]
+    assert any(pool["name"] == "standard" for pool in pools)
+
+
+def test_gacha_draw_spends_balance_and_returns_items(client):
+    user_id = "gacha-master"
+    _seed_wallet(client, user_id, amount=150)
+
+    draw_response = client.post(
+        "/gacha/draw",
+        json={"user_id": user_id, "pool": "standard", "draws": 3, "seed": 42},
+    )
+    assert draw_response.status_code == 200
+
+    draw_data = draw_response.get_json()["data"]
+    assert draw_data["pool"] == "standard"
+    assert draw_data["draws"] == 3
+    assert len(draw_data["items"]) == 3
+    assert draw_data["remaining_balance"] == 120.0
+
+    wallet_response = client.get(f"/wallets/{user_id}")
+    wallet_balance = wallet_response.get_json()["data"]["wallet"]["balance"]
+    assert wallet_balance == 120.0
+
+
+def test_gacha_draw_requires_funds(client):
+    response = client.post("/gacha/draw", json={"user_id": "no-money", "draws": 1})
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["message"] == "Fonds insuffisants"
+

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,51 @@
+"""Tests pour la gestion des portefeuilles."""
+
+
+def test_wallet_topup_and_spend_flow(client):
+    user_id = "joueur-1"
+
+    response = client.post(f"/wallets/{user_id}/topup", json={"amount": 100, "source": "shop"})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["data"]["wallet"]["balance"] == 100.0
+
+    response = client.get(f"/wallets/{user_id}")
+    assert response.status_code == 200
+    wallet_data = response.get_json()["data"]["wallet"]
+    assert wallet_data["balance"] == 100.0
+
+    response = client.post(
+        f"/wallets/{user_id}/spend",
+        json={"amount": "12.50", "reason": "purchase", "metadata": {"item": "skin"}},
+    )
+    assert response.status_code == 200
+    spend_data = response.get_json()["data"]
+    assert spend_data["wallet"]["balance"] == 87.5
+    assert spend_data["transaction"]["metadata"]["reason"] == "purchase"
+
+    response = client.get(f"/wallets/{user_id}/transactions")
+    transactions_payload = response.get_json()["data"]["transactions"]
+    assert len(transactions_payload) == 2
+    amounts = sorted(tx["amount"] for tx in transactions_payload)
+    assert amounts == [12.5, 100.0]
+
+
+def test_wallet_prevents_negative_or_invalid_amount(client):
+    response = client.post("/wallets/u1/topup", json={"amount": -10})
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+
+    response = client.post("/wallets/u1/spend", json={"amount": "abc"})
+    assert response.status_code == 400
+
+
+def test_wallet_spend_rejects_when_balance_is_too_low(client):
+    user_id = "pauvre-joueur"
+
+    response = client.post(f"/wallets/{user_id}/spend", json={"amount": 5})
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["error"]["detail"].startswith("Fonds insuffisants")
+


### PR DESCRIPTION
## Summary
- implement in-memory wallet store with top-up, spend, and transaction history endpoints
- add gacha pools with draw endpoint consuming wallet balance and deterministic seeding support
- document the new API surface and cover flows with integration-style tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d97e6cab50833292dbe228a5674b8b